### PR TITLE
Add PS/2 mouse support with cursor rendering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ COMMON_OBJS = boot/kernel_entry.o \
               kernel/conio.o kernel/kernel_command.o kernel/math.o kernel/fpu.o \
               kernel/mem.o kernel/time.o kernel/util.o kernel/perf.o \
               drivers/debug.o drivers/display.o drivers/hdd.o drivers/hidden_cmd.o \
-              drivers/keyboard.o drivers/ports.o drivers/video.o drivers/dma.o \
+              drivers/keyboard.o drivers/mouse.o drivers/ports.o drivers/video.o drivers/dma.o \
               cpu/idt.o cpu/isr.o cpu/timer.o \
               stdlibs/file.o stdlibs/memory.o stdlibs/stdio.o stdlibs/string.o \
               stdlibs/textui.o stdlibs/tinysql.o \

--- a/drivers/mouse.c
+++ b/drivers/mouse.c
@@ -1,0 +1,63 @@
+#include <stdint.h>
+#include "mouse.h"
+#include "ports.h"
+#include "../cpu/isr.h"
+
+static int mouse_x = 0;
+static int mouse_y = 0;
+
+static void mouse_wait(uint8_t type) {
+    uint32_t timeout = 100000;
+    if(type == 0) {
+        while(timeout-- && !(port_byte_in(0x64) & 1));
+    } else {
+        while(timeout-- && (port_byte_in(0x64) & 2));
+    }
+}
+
+static void mouse_write(uint8_t data) {
+    mouse_wait(1);
+    port_byte_out(0x64, 0xD4);
+    mouse_wait(1);
+    port_byte_out(0x60, data);
+}
+
+static uint8_t mouse_read() {
+    mouse_wait(0);
+    return port_byte_in(0x60);
+}
+
+static void mouse_callback(registers_t *regs) {
+    (void)regs;
+    static uint8_t cycle = 0;
+    static int8_t packet[3];
+    packet[cycle++] = mouse_read();
+    if(cycle == 3) {
+        cycle = 0;
+        int dx = packet[1];
+        int dy = -packet[2];
+        mouse_x += dx;
+        mouse_y += dy;
+        if(mouse_x < 0) mouse_x = 0;
+        if(mouse_y < 0) mouse_y = 0;
+    }
+}
+
+void mouse_install() {
+    uint8_t status;
+    mouse_wait(1); port_byte_out(0x64, 0xA8);
+    mouse_wait(1); port_byte_out(0x64, 0x20);
+    mouse_wait(0); status = port_byte_in(0x60);
+    status |= 0x02;
+    mouse_wait(1); port_byte_out(0x64, 0x60);
+    mouse_wait(1); port_byte_out(0x60, status);
+    mouse_write(0xF6); mouse_read();
+    mouse_write(0xF4); mouse_read();
+    register_interrupt_handler(IRQ12, mouse_callback);
+}
+
+void mouse_get_position(int *x, int *y) {
+    if(x) *x = mouse_x;
+    if(y) *y = mouse_y;
+}
+

--- a/drivers/mouse.h
+++ b/drivers/mouse.h
@@ -1,0 +1,9 @@
+#ifndef MOUSE_H
+#define MOUSE_H
+
+#include <stdint.h>
+
+void mouse_install();
+void mouse_get_position(int *x, int *y);
+
+#endif

--- a/kernel/bga_minimal.c
+++ b/kernel/bga_minimal.c
@@ -4,6 +4,7 @@
 #include "../kernel/math.h"
 #include "../drivers/ports.h"
 #include "../drivers/keyboard.h"
+#include "../drivers/mouse.h"
 #include "../drivers/debug.h"
 #include "../drivers/display.h"
 #include "../drivers/video.h"
@@ -366,6 +367,11 @@ int bgademo2(void) {
 
             // render text buffer
             render_textbuf((uint32_t*)drawbuf,width,0x00FFFFFF,0x00000000);
+            int mx, my;
+            mouse_get_position(&mx, &my);
+            if(mx>width-8) mx=width-8;
+            if(my>height-16) my=height-16;
+            draw_text((uint32_t*)drawbuf, width, mx, my, "X", 0x00FFFFFF, 0x00000000, 1);
 
             // 3d triangle vertices
             Vertex v0={-50,-50, 100, 0xFF0000};
@@ -497,6 +503,11 @@ int bgademo(void) {
 
             // render text buffer
             render_textbuf((uint32_t*)drawbuf,width,0x00FFFFFF,0x00000000);
+            int mx, my;
+            mouse_get_position(&mx, &my);
+            if(mx>width-8) mx=width-8;
+            if(my>height-16) my=height-16;
+            draw_text((uint32_t*)drawbuf, width, mx, my, "X", 0x00FFFFFF, 0x00000000, 1);
 
             // *** kopien erzeugen und rotieren ***
             Vertex v0=base0, v1=base1, v2=base2;

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -3,6 +3,7 @@
 #include "../cpu/timer.h"
 #include "../drivers/display.h"
 #include "../drivers/keyboard.h"
+#include "../drivers/mouse.h"
 #include "../drivers/ports.h"
 #include "../drivers/video.h"
 #include "../stdlibs/string.h"
@@ -197,8 +198,8 @@ void kernel_main() {
         print_string("Initializing timer millisecond.\n");
         init_timer(1000);
 
-        //print_string("Initializing PS/2 mouse interface.\n");;
-        //mouse_install();
+        print_string("Initializing PS/2 mouse interface.\n");
+        mouse_install();
 
         print_string("Initializing random number generator.\n");;
         init_random();


### PR DESCRIPTION
## Summary
- implement basic PS/2 mouse driver with position tracking
- initialize mouse during kernel startup
- render simple ASCII cursor in BGA demo and include driver in build

## Testing
- `make kernel.bin`

------
https://chatgpt.com/codex/tasks/task_e_68a7e2ef25ec832396ba5487dcda212e