### PR TITLE
Handle mouse packets in getkey_async

### DIFF
--- a/drivers/keyboard.c
+++ b/drivers/keyboard.c
@@ -186,6 +186,10 @@ unsigned int getkey() {
 
 unsigned int getkey_async() {
     sleep(10);
+    uint8_t status = read_keyboard_status();
+    if (!(status & 0x01) || (status & 0x20)) {
+        return 0;
+    }
     uint8_t scancode = read_keyboard_data();
     return extended_scancode ? (0xE0 << 8 | scancode) : scancode;
 }


### PR DESCRIPTION
## Summary
- Avoid reading port 0x60 when the keyboard status indicates no data or a mouse packet
- Return 0 from `getkey_async` if no keyboard data is ready

## Testing
- `make kernel.bin`


------
https://chatgpt.com/codex/tasks/task_e_68a8961d14908323828cd95bbb1ef5ac