### PR TITLE
Fix demo exit and DTMF commands by buffering keyboard input

### DIFF
--- a/drivers/keyboard.h
+++ b/drivers/keyboard.h
@@ -141,5 +141,6 @@ extern struct KeyData keyData[];
 void init_keyboard();
 bool is_key_pressed(unsigned int scancode);
 unsigned int getkey();
+unsigned int getkey_async();
 
 #endif


### PR DESCRIPTION
## Summary
- buffer keyboard scancodes in a ring buffer to keep key events after IRQ handling
- expose async getkey and use buffered input so ESC and command keys work reliably

## Testing
- `make drivers/keyboard.o`
- `make test-env` (fails: `/bin/sh: 3: Syntax error: Unterminated quoted string`)


------
https://chatgpt.com/codex/tasks/task_e_68a89cb8214883239b956ddc92a379ad