### PR TITLE
Add CPU info and help command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ COMMON_OBJS = boot/kernel_entry.o \
               drivers/debug.o drivers/display.o drivers/hdd.o drivers/hidden_cmd.o \
               drivers/keyboard.o drivers/mouse.o drivers/ports.o drivers/video.o drivers/dma.o \
               cpu/idt.o cpu/isr.o cpu/timer.o \
+              cpu/cpuinfo.o \
               stdlibs/file.o stdlibs/memory.o stdlibs/stdio.o stdlibs/string.o \
               stdlibs/textui.o stdlibs/tinysql.o \
               programs/editor.o programs/hexviewer.o \

--- a/cpu/cpuinfo.c
+++ b/cpu/cpuinfo.c
@@ -1,0 +1,42 @@
+#include "cpuinfo.h"
+#include "../drivers/display.h"
+#include "../stdlibs/string.h"
+#include <stdint.h>
+
+void cpuinfo(void) {
+    uint32_t eax, ebx, ecx, edx;
+    char vendor[13];
+
+    __asm__ __volatile__("cpuid" : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(0));
+    *(uint32_t *)&vendor[0] = ebx;
+    *(uint32_t *)&vendor[4] = edx;
+    *(uint32_t *)&vendor[8] = ecx;
+    vendor[12] = '\0';
+    printf("Vendor: %s\n", vendor);
+
+    char brand[49];
+    uint32_t *brand_u32 = (uint32_t *)brand;
+    for (uint32_t i = 0; i < 3; i++) {
+        __asm__ __volatile__("cpuid" : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(0x80000002 + i));
+        brand_u32[i * 4 + 0] = eax;
+        brand_u32[i * 4 + 1] = ebx;
+        brand_u32[i * 4 + 2] = ecx;
+        brand_u32[i * 4 + 3] = edx;
+    }
+    brand[48] = '\0';
+    printf("Brand: %s\n", brand);
+
+    __asm__ __volatile__("cpuid" : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(1));
+    printf("Stepping %d, Model %d, Family %d\n", eax & 0xf, (eax >> 4) & 0xf, (eax >> 8) & 0xf);
+    printf("Features: ");
+    if (edx & (1 << 4)) printf("TSC ");
+    if (edx & (1 << 23)) printf("MMX ");
+    if (edx & (1 << 25)) printf("SSE ");
+    if (edx & (1 << 26)) printf("SSE2 ");
+    if (ecx & (1 << 0)) printf("SSE3 ");
+    if (ecx & (1 << 9)) printf("SSSE3 ");
+    if (ecx & (1 << 19)) printf("SSE4.1 ");
+    if (ecx & (1 << 20)) printf("SSE4.2 ");
+    printf("\n");
+}
+

--- a/cpu/cpuinfo.h
+++ b/cpu/cpuinfo.h
@@ -1,0 +1,2 @@
+#pragma once
+void cpuinfo(void);

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -8,6 +8,7 @@
 #include "../drivers/video.h"
 #include "../stdlibs/string.h"
 #include "../cpu/jmpbuf.h"
+#include "../cpu/cpuinfo.h"
 
 #include "kernel.h"
 #include "util.h"
@@ -241,6 +242,7 @@ void kernel_console_execute_command(char *input) {
     if (strcmp(input, "") == 0) { goto none; }
 
     CALL_FUNCTION(msgbox)
+    CALL_FUNCTION(help)
     CALL_FUNCTION_ALIAS(pl, printlist)
     CALL_FUNCTION_ALIAS(pv, print_select_list_vertical)
     CALL_FUNCTION(memtest)
@@ -274,6 +276,7 @@ void kernel_console_execute_command(char *input) {
     CALL_FUNCTION(hidecursor)
     CALL_FUNCTION(showcursor)
     CALL_FUNCTION(print_registers)
+    CALL_FUNCTION(cpuinfo)
     CALL_FUNCTION(keycodes)
     CALL_FUNCTION(exit)
     CALL_FUNCTION(loaddisk) 

--- a/kernel/kernel_command.c
+++ b/kernel/kernel_command.c
@@ -6,9 +6,69 @@
 #include "../drivers/keyboard.h"
 #include "../drivers/display.h"
 #include "../cpu/jmpbuf.h"
+#include "../cpu/cpuinfo.h"
 
 extern bool g_bKernelShouldStop;
 extern jmp_buf g_jmpKernelMain;
+
+typedef struct {
+    const char *name;
+    const char *desc;
+} help_entry;
+
+static const help_entry g_help_entries[] = {
+    {"help", "List kernel commands"},
+    {"cpuinfo", "Show CPU information"},
+    {"msgbox", "Show message box"},
+    {"pl", "Print list"},
+    {"pv", "Print vertical list"},
+    {"memtest", "Run memory test"},
+    {"cls/clear/clr/rst/reset", "Clear screen"},
+    {"killtimer", "Stop PIT timer"},
+    {"bell", "Play bell"},
+    {"snaketext", "Snake text demo"},
+    {"ramdisk_test", "Test RAM disk"},
+    {"tinysql", "Start TinySQL"},
+    {"tinysql2", "Start TinySQL2"},
+    {"restart", "Restart kernel"},
+    {"main_c", "Run C main"},
+    {"em", "Text editor"},
+    {"demo", "BGA demo"},
+    {"sb16", "SB16 demo"},
+    {"dtmf", "Generate DTMF tones"},
+    {"setpal", "Change palette"},
+    {"snake_main", "Snake game"},
+    {"random", "Random numbers"},
+    {"uptime", "Show uptime"},
+    {"hidecursor", "Hide cursor"},
+    {"showcursor", "Show cursor"},
+    {"print_registers", "Dump registers"},
+    {"keycodes", "Keyboard scancodes"},
+    {"exit", "Leave kernel"},
+    {"loaddisk", "Load disk"},
+    {"printascii", "ASCII table"},
+    {"cat <addr>", "Print memory"},
+    {"hexviewer <addr>", "Hex viewer"},
+    {"run <addr>", "Jump to address"},
+    {"hexdump <addr> <len>", "Hex dump"},
+    {"memset <addr> <len>", "Fill memory"},
+    {"memcpy <src> <dst> <len>", "Copy memory"},
+    {"searchb <addr> <len> <b>", "Search byte"},
+    {"beep <freq> <ms>", "PC speaker"},
+    {"printf \"fmt\"", "Formatted print"},
+    {"searchs <addr> <len> <str>", "Search string"}
+};
+
+void help(void) {
+    int count = sizeof(g_help_entries) / sizeof(g_help_entries[0]);
+    for (int i = 0; i < count; i += 2) {
+        printf("%-20s - %-28s", g_help_entries[i].name, g_help_entries[i].desc);
+        if (i + 1 < count) {
+            printf("%-20s - %s", g_help_entries[i + 1].name, g_help_entries[i + 1].desc);
+        }
+        printf("\n");
+    }
+}
 
 void searchb(uint32_t address, uint32_t size, uint32_t byte) {
         printf("Searching %d\n", byte);


### PR DESCRIPTION
## Summary
- add `cpuinfo` command that outputs vendor, brand, model and CPU features
- introduce `help` command listing kernel commands in two columns with brief descriptions
- register new `cpuinfo` module in build system

## Testing
- `make kernel.bin`


------
https://chatgpt.com/codex/tasks/task_e_68a8b4b784948323a60d5beb68b14bf0